### PR TITLE
fix(security): exclude chrome-sandbox

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,10 @@ parts:
       # Correct path to icon.
       grep Icon $SNAPCRAFT_PART_INSTALL/usr/share/applications/inkdrop.desktop
       sed -i 's|Icon=inkdrop|Icon=/usr/share/pixmaps/inkdrop\.png|g' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/inkdrop.desktop
+      sed -i 's|%U|--no-sandbox %U|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/inkdrop.desktop
       grep Icon $SNAPCRAFT_PART_INSTALL/usr/share/applications/inkdrop.desktop
+    prime:
+      - -usr/lib/inkdrop/chrome-sandbox
     build-packages:
       - curl
     stage-packages:


### PR DESCRIPTION
The automatic review failed with the following errors:

```
> sudo snap install review-tools
> snap-review inkdrop_4.4.0_amd64.snap

Errors
------
 - security-snap-v2:squashfs_files
        found errors in file output: unusual mode 'rwsr-xr-x' for entry './usr/lib/inkdrop/chrome-sandbox'
 - security-snap-v2:squashfs_repack_checksum
        checksums do not match. Please ensure the snap is created with either 'snapcraft pack <DIR>' (using snapcraft >= 2.38) or 'mksquashfs <dir> <snap> -noappend -comp xz -all-
root -no-xattrs -no-fragments'. If using electron-builder, please upgrade to latest stable (>= 20.14.7). See https://forum.snapcraft.io/t/automated-reviews-and-snapcraft-2-38/498$
/17 for details.
        https://forum.snapcraft.io/t/automated-reviews-and-snapcraft-2-38/4982/17
inkdrop_4.4.0_amd64.snap: FAIL
```

Excluding `chrome-sandbox` would solve these errors. It is not necessary to run the app.